### PR TITLE
G34uCPYu: add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "BAU"


### PR DESCRIPTION
This is sample code, so it shouldn't matter which versions of dependencies we use. However, it's good practice to keep our dependencies up to date. Dependabot makes it easy to do so.