### PR TITLE
BAU: add type hints to function signatures

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -19,6 +19,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint -r requirements.txt
+        pip install pylint mypy -r requirements.txt
     - name: Lint with pylint
       run: pylint client
+    - name: Type check with mypy
+      run: mypy client

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,3 +1,5 @@
 #! /bin/bash
+set -eou pipefail
 
-pylint ./**/*.py 
+pylint client
+mypy client


### PR DESCRIPTION
[Type hints](https://www.python.org/dev/peps/pep-0484/) were introduced in Python 3.5 as a way of documenting the types used. They can be consumed by type checkers such as mypy (and other tools/linters/IDEs/etc.). Add type hints to our function signatures to make it slightly clearer what all the functions are doing and what their inputs are.

Add mypy to CI and the pre-commit script to help make sure the type hints are correct and kept up to date.